### PR TITLE
Missing datetimes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,5 +34,5 @@ docs/
 po/*~
 # RStudio Connect folder
 rsconnect/
-# large files
-example_data.csv
+# data
+*.csv

--- a/gsi_wrangling.Rmd
+++ b/gsi_wrangling.Rmd
@@ -57,7 +57,7 @@ if ("gsi_living_lab_data.csv" %in% files$name) {
 
 new_dat <- gsi_get_data(start = prev_end)
 
-# bind old to new and write back to box
+# bind old to new
 all_dat <- 
   bind_rows(old_dat, new_dat) |> 
   filter(!is.na(sensor)) |> # this is somewhat redundant, but having this in gsi_get_data() only removes these from new data
@@ -65,21 +65,15 @@ all_dat <-
   arrange(datetime) 
 ```
 
-Missing data due to a device being offline is only indicated by missing datetimes.  For easier nicer plotting, it's probably better to fill those missing datetimes in.
+Missing data due to a device being offline is only indicated by missing datetimes. This next chunk makes missing datetimes explicit.
 
 ```{r}
-#Create data frame of expected datetimes for all device, sensor, port combinations in the current data
-expected_datetimes <- 
-  expand_grid(
-    datetime = seq(min(all_dat$datetime), max(all_dat$datetime), by = "hour"),
-    device_sensor_port = unique(paste(all_dat$device_sn, all_dat$sensor, all_dat$port, sep = "_"))
-  ) |> 
-  separate_wider_delim(device_sensor_port, delim = "_", names = c("device_sn", "sensor", "port")) |> 
-  mutate(port = as.numeric(port))
-
-#Join to full data to add rows of NAs in all the data columns
-all_dat_final <- full_join(all_dat, expected_datetimes)
-
+all_dat_final <-
+  all_dat |> 
+  complete(
+    nesting(device_sn, sensor, port),
+    datetime = seq(min(datetime), max(datetime), by = "hour")
+  )
 ```
 
 

--- a/gsi_wrangling.Rmd
+++ b/gsi_wrangling.Rmd
@@ -55,13 +55,37 @@ if ("gsi_living_lab_data.csv" %in% files$name) {
 
 # Get the data and wrangle it
 
-all_df <- gsi_get_data(start = prev_end)
+new_dat <- gsi_get_data(start = prev_end)
 
 # bind old to new and write back to box
-bind_rows(old_dat, all_df) |> 
+all_dat <- 
+  bind_rows(old_dat, new_dat) |> 
   filter(!is.na(sensor)) |> # this is somewhat redundant, but having this in gsi_get_data() only removes these from new data
   distinct() |> #remove duplicate rows
-  arrange(datetime) |> 
-  box_write("gsi_living_lab_data.csv", write_fun = readr::write_csv)
+  arrange(datetime) 
+```
+
+Missing data due to a device being offline is only indicated by missing datetimes.  For easier nicer plotting, it's probably better to fill those missing datetimes in.
+
+```{r}
+#Create data frame of expected datetimes for all device, sensor, port combinations in the current data
+expected_datetimes <- 
+  expand_grid(
+    datetime = seq(min(all_dat$datetime), max(all_dat$datetime), by = "hour"),
+    device_sensor_port = unique(paste(all_dat$device_sn, all_dat$sensor, all_dat$port, sep = "_"))
+  ) |> 
+  separate_wider_delim(device_sensor_port, delim = "_", names = c("device_sn", "sensor", "port")) |> 
+  mutate(port = as.numeric(port))
+
+#Join to full data to add rows of NAs in all the data columns
+all_dat_final <- full_join(all_dat, expected_datetimes)
+
+```
+
+
+## Write data to box
+
+```{r}
+box_write(all_dat_final, "gsi_living_lab_data.csv", write_fun = readr::write_csv)
 ```
 


### PR DESCRIPTION
When @MJBarrios and I were working on plotting the data, I realized that there are missing datetimes in the dataset when devices were not operational. This results in a "connect the dots" line in a timeseries plot like so:
![Screenshot 2023-12-05 at 3 39 17 PM](https://github.com/UArizonaGSICampusLivingLab/gsi-wrangling-workflow/assets/25404783/806794dd-5e8e-4646-a2cf-8f1d0f0fbec5)


If those missing datetimes are filled in, with all values for the numeric data set to `NA` it looks like this:
![Screenshot 2023-12-05 at 3 39 24 PM](https://github.com/UArizonaGSICampusLivingLab/gsi-wrangling-workflow/assets/25404783/94e676f7-5745-4ac5-b1da-95733aa1ffa0)

This PR adds the missing datetimes  *in the data on Box*—I'm not sure if that's what you want.  If it is what you want, should there be some indication of why those datetimes have missing data?  E.g. we could set the `*.error_flag` column to say something like "Device offline"?