### PR TITLE
Migrate output to new box folder and use new API token

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,7 @@ po/*~
 rsconnect/
 # data
 *.csv
+
+# Rendered files
+*.html
+

--- a/R/gsi_get_data.R
+++ b/R/gsi_get_data.R
@@ -11,7 +11,12 @@ gsi_get_data <-
     
   # Occasionally the API returns a "429 - Too Many Requests" error despite rate limiting being built into getReadings(), so we create a version that will retry on error
     insistent_getReadings <- 
-      purrr::insistently(getReadings, quiet = FALSE)
+      purrr::insistently(getReadings,
+                         rate = rate_backoff(
+                           pause_cap = 90,
+                           max_times = 5,
+                         ), 
+                         quiet = FALSE)
     
   readings_all <- 
     # provide an "anonymous function" to map() to iterate over `devices`

--- a/gsi_wrangling.Rmd
+++ b/gsi_wrangling.Rmd
@@ -34,7 +34,7 @@ Publishing this workflow to Posit Connect will fail the first time because the e
 ```{r auth}
 box_auth_service(token_text = Sys.getenv("BOX_TOKEN_TEXT"))
 # box_auth() ## If you want to run locally use this instead of box_auth_service()
-dir_id <- "233031886906"
+dir_id <- "250527085917"
 box_setwd(dir_id)
 #list current files
 files <- box_ls() |> as_tibble()


### PR DESCRIPTION
Uses the new API token that replaces vapor pressure with RH and saves the output in a new Box folder under the one shared with me that has unlimited storage