### PR TITLE
Eto duplicates

### DIFF
--- a/.Rprofile
+++ b/.Rprofile
@@ -1,4 +1,1 @@
 source("renv/activate.R")
-options(
-  repos = c(r_universe = 'https://cct-datascience.r-universe.dev', getOption("repos"))
-)

--- a/R/gsi_get_data.R
+++ b/R/gsi_get_data.R
@@ -1,4 +1,4 @@
-# getReadings() errors when there is no data returned, but I'd rather it return an empty tibble, so I'll wrap it here.  See: https://gitlab.com/meter-group-inc/pubpackages/zentracloud/-/issues/44
+# getReadings() errors when there is no data returned, but I'd rather it return `NULL`, so I'll wrap it here.  See: https://gitlab.com/meter-group-inc/pubpackages/zentracloud/-/issues/44
 my_getReadings <- function(...) {
   tryCatch(
     error = function(cnd) {

--- a/R/gsi_get_data.R
+++ b/R/gsi_get_data.R
@@ -1,3 +1,27 @@
+# getReadings() errors when there is no data returned, but I'd rather it return an empty tibble, so I'll wrap it here.  See: https://gitlab.com/meter-group-inc/pubpackages/zentracloud/-/issues/44
+my_getReadings <- function(...) {
+  tryCatch(
+    error = function(cnd) {
+      if (stringr::str_detect(as.character(cnd), "The API does not return any data")) {
+        warning(simpleWarning(conditionMessage(cnd)))
+        return(NULL)
+      } else {
+        stop(cnd)
+      }
+    },
+    zentracloud::getReadings(...)
+  )
+}
+
+# Occasionally the API returns a "429 - Too Many Requests" error despite rate limiting being built into getReadings(), so we create a version that will retry on *that* error
+insistent_getReadings <- 
+  purrr::insistently(my_getReadings,
+                     rate = rate_backoff(
+                       pause_cap = 90,
+                       max_times = 8,
+                     ), 
+                     quiet = FALSE)
+
 gsi_get_data <- 
   function(start, end = NULL, devices = c("z6-19484", "z6-19485", "z6-20761", "z6-20764", "z6-20762", "z6-20763")) {
 
@@ -8,42 +32,39 @@ gsi_get_data <-
     }
     
   # Download data -----------------------------------------------------------
-    
-  # Occasionally the API returns a "429 - Too Many Requests" error despite rate limiting being built into getReadings(), so we create a version that will retry on error
-    insistent_getReadings <- 
-      purrr::insistently(getReadings,
-                         rate = rate_backoff(
-                           pause_cap = 90,
-                           max_times = 5,
-                         ), 
-                         quiet = FALSE)
-    
+  
   readings_all <- 
     # provide an "anonymous function" to map() to iterate over `devices`
-    map(devices, \(x) {
+    purrr::map(devices, \(x) {
       insistent_getReadings(
         device_sn  = x,
         start_time = format(start, "%Y-%m-%d %H:%M:%S"), 
         end_time   = format(end, "%Y-%m-%d %H:%M:%S")
       )
-    }) |> set_names(devices)
+    }) |> 
+    purrr::set_names(devices) |> 
+    purrr::compact() #get rid of NULLs for when some sensors return no data
 
+  # and if all the sensors return no data, just return an empty tibble
+  if (length(readings_all) == 0) {
+    return(tibble())
+  }
   # Wrangle data ------------------------------------------------------------
   all_df <- 
     readings_all |> 
     # collapse list of lists to list of data frames
-    map(\(x) list_rbind(x, names_to = "sensor_port")) |> 
+    purrr::map(\(x) purrr::list_rbind(x, names_to = "sensor_port")) |> 
     # collapse list of data frames to a single data frame
-    list_rbind(names_to = "device_sn") |> 
+    purrr::list_rbind(names_to = "device_sn") |> 
     # some initial data wrangling
-    separate_wider_delim(sensor_port, delim = "_", names = c("sensor", "port")) |> 
+    tidyr::separate_wider_delim(sensor_port, delim = "_", names = c("sensor", "port")) |> 
     mutate(
-      port = str_remove(port, "port") |> as.numeric(),
-      datetime = parse_date_time(datetime, orders = "%Y-%m-%d %H:%M:%S%z", exact = TRUE) |> 
+      port = stringr::str_remove(port, "port") |> as.numeric(),
+      datetime = lubridate::parse_date_time(datetime, orders = "%Y-%m-%d %H:%M:%S%z", exact = TRUE) |> 
         with_tz("America/Phoenix")
     ) |> 
-    filter(!is.na(sensor)) |> #There are some NAs for `sensor` in some versions of the wrangled data.  This removes them.
-    select(-timestamp_utc, -tz_offset) #redundant columns
+    dplyr::filter(!is.na(sensor)) |> #There are some NAs for `sensor` in some versions of the wrangled data.  This removes them.
+    dplyr::select(-timestamp_utc, -tz_offset) #redundant columns
   
   #return
   all_df

--- a/gsi_wrangling.Rmd
+++ b/gsi_wrangling.Rmd
@@ -66,7 +66,7 @@ if ("gsi_living_lab_data.csv" %in% files$name) {
 
 Retrieve new data
 
-```{r update_data, results='hide'}
+```{r update_data, results='hide', message=FALSE}
 # Get the data and wrangle it
 new_dat <-
   gsi_get_data(start = prev_end)
@@ -128,15 +128,17 @@ inputs <-
 
 Use site info to get most recent ETo values for all locations from the Zentra Cloud API
 
-```{r eto_get, results='hide'}
+```{r eto_get, results='hide', message=FALSE}
 eto_list <- pmap(inputs, gsi_get_eto)
 eto_new <- list_rbind(eto_list)
 ```
 
-Zentra Cloud appears to calculate daily ETo even with partial hourly data for a day, so the last date of `eto_new` (i.e. today) is not reliable and gets removed.
+Zentra Cloud appears to calculate daily ETo even with partial hourly data for a day, so the oldest date of `eto_new` is not reliable and gets removed.
 
 ```{r eto_new}
-eto_new <- eto_new |> filter(datetime != min(datetime, na.rm = TRUE))
+eto_new <- 
+  eto_new |> 
+  filter(datetime != min(datetime, na.rm = TRUE))
 ```
 
 Read in previously saved ETo data and join.
@@ -156,15 +158,15 @@ if ("gsi_living_lab_ETo.csv" %in% files$name) {
 Zentracloud calculates daily ETo even with partial hourly data, so if data is uploaded retroactively, ETo values may update.  If that is the case, we keep only the new, updated values.
 
 ```{r eto_update}
-
 eto_updates <- 
-  left_join(
+  full_join(
     eto_prev |> select(device_sn, port, datetime, ETo.value),
     eto_new |> select(device_sn, port, datetime, ETo.value),
     by = join_by(device_sn, port, datetime),
     suffix = c("_old", "")
   )
 ```
+
 
 ```{r eto_diffs}
 eto_diffs <- eto_updates |> 

--- a/gsi_wrangling.Rmd
+++ b/gsi_wrangling.Rmd
@@ -127,13 +127,13 @@ eto_new <- list_rbind(eto_list)
 
 The last date of `eto_new` is not reliable as of 02-09-2024.  It has different values compared to the same date in `eto_prev.`  My guess is this is due to partial days being summarized instead of rounding off to the nearest day when getting the prev 30 days.  I'll just remove it.
 
-```{r}
+```{r eto_new}
 eto_new <- eto_new |> filter(datetime != min(datetime, na.rm = TRUE))
 ```
 
 Read in previously saved ETo data and join.
 
-```{r eto_update}
+```{r eto_prev}
 if ("gsi_living_lab_ETo.csv" %in% files$name) {
   eto_prev <- 
     files |> 
@@ -143,23 +143,36 @@ if ("gsi_living_lab_ETo.csv" %in% files$name) {
 } else {
   eto_prev <- tibble()
 }
-
-eto_full <-
-  bind_rows(eto_prev, eto_new) |> 
-  arrange(datetime, device_sn) |> 
-  distinct() #keep only one row per site per date
-
-#check that there is just one unique value per site per date
-ns <- 
-  eto_full |>
-  count(device_sn, datetime) |>
-  pull(n)
-if(!all(ns == 1)) {
-  stop("More than one unique value for ETo! Reconcile before publishing data")
-}
-
 ```
 
+Zentracloud calculates daily ETo even with partial hourly data, so if data is uploaded retroactively, ETo values may update.  If that is the case, we keep only the new, updated values.
+
+```{r eto_update}
+
+eto_updates <- 
+  left_join(
+    eto_prev |> select(device_sn, port, datetime, ETo.value),
+    eto_new |> select(device_sn, port, datetime, ETo.value),
+    by = join_by(device_sn, port, datetime),
+    suffix = c("_old", "")
+  )
+```
+
+```{r eto_diffs}
+eto_diffs <- eto_updates |> 
+  filter(ETo.value != ETo.value_old)
+if (nrow(eto_diffs) > 0) {
+  warning("Some values of ETo have changed on Zentra Cloud---updating the following values:")
+  eto_diffs
+}
+```
+
+```{r}
+#Overwrite old values with new ones (unless they are old enough to be missing from the new values)
+eto_full <- eto_updates |> 
+  mutate(ETo.value = ifelse(is.na(ETo.value), ETo.value_old, ETo.value)) |> 
+  select(-ETo.value_old)
+```
 
 ## Write data to box
 

--- a/gsi_wrangling.Rmd
+++ b/gsi_wrangling.Rmd
@@ -80,7 +80,8 @@ Add columns for adjusted temperature (wind chill and heat index) and plant avail
 new_dat <- 
   new_dat |>
   mutate(
-    air_temperature_adj.value = calc_hi(air_temperature.value, relative_humidity.value) |>
+    air_temperature_adj.value = 
+      calc_hi(air_temperature.value, relative_humidity.value) |>
       calc_wind_chill(wind_speed.value) |>
       round(digits = 1),
     paw.value = (water_content.value - 0.06) / 0.11 * 100
@@ -121,9 +122,15 @@ site_info <-
   box_read()
 
 inputs <-
-  site_info |> 
-  filter(sensor_model == "ATMOS41") |> 
-  select(device_sn, port_num = port, wind_height = depth_height_m, elevation = Elevation, latitude = Latitude)
+  site_info |>
+  filter(sensor_model == "ATMOS41") |>
+  select(
+    device_sn,
+    port_num = port,
+    wind_height = depth_height_m,
+    elevation = Elevation,
+    latitude = Latitude
+  )
 ```
 
 Use site info to get most recent ETo values for all locations from the Zentra Cloud API

--- a/gsi_wrangling.Rmd
+++ b/gsi_wrangling.Rmd
@@ -2,7 +2,9 @@
 title: "Green Stormwater Infrastructure Data Wrangling"
 author: "Eric R. Scott"
 date: "`r Sys.Date()`"
-output: html_document
+output: 
+  html_document:
+    code_folding: hide
 resource_files:
 - renv.lock
 ---
@@ -46,7 +48,9 @@ files <- box_ls() |> as_tibble()
 
 ### Hourly data
 
-```{r update_data}
+Retrieve the data already on box
+
+```{r old_data}
 #does gsi_living_lab_data.csv exist already?
 if ("gsi_living_lab_data.csv" %in% files$name) {
   old_dat <- files |> 
@@ -58,7 +62,11 @@ if ("gsi_living_lab_data.csv" %in% files$name) {
   old_dat <- tibble()
   prev_end <- ymd("2023-06-05", tz = "America/Phoenix") #first date of data
 }
+```
 
+Retrieve new data
+
+```{r update_data, results='hide'}
 # Get the data and wrangle it
 new_dat <-
   gsi_get_data(start = prev_end)
@@ -103,7 +111,7 @@ all_dat_final <-
 
 ### ETo
 
-Get site_info.csv from box
+Get `site_info.csv` from box
 
 ```{r eto_siteinfo}
 site_info <- 
@@ -118,14 +126,14 @@ inputs <-
   select(device_sn, port_num = port, wind_height = depth_height_m, elevation = Elevation, latitude = Latitude)
 ```
 
-Use site info to get most recent ETo values for all locations from API
+Use site info to get most recent ETo values for all locations from the Zentra Cloud API
 
-```{r eto_get}
+```{r eto_get, results='hide'}
 eto_list <- pmap(inputs, gsi_get_eto)
 eto_new <- list_rbind(eto_list)
 ```
 
-The last date of `eto_new` is not reliable as of 02-09-2024.  It has different values compared to the same date in `eto_prev.`  My guess is this is due to partial days being summarized instead of rounding off to the nearest day when getting the prev 30 days.  I'll just remove it.
+Zentra Cloud appears to calculate daily ETo even with partial hourly data for a day, so the last date of `eto_new` (i.e. today) is not reliable and gets removed.
 
 ```{r eto_new}
 eto_new <- eto_new |> filter(datetime != min(datetime, na.rm = TRUE))

--- a/renv.lock
+++ b/renv.lock
@@ -3,26 +3,6 @@
     "Version": "4.3.3",
     "Repositories": [
       {
-        "Name": "r_universe",
-        "URL": "https://cct-datascience.r-universe.dev"
-      },
-      {
-        "Name": "r_universe",
-        "URL": "https://cct-datascience.r-universe.dev"
-      },
-      {
-        "Name": "r_universe",
-        "URL": "https://cct-datascience.r-universe.dev"
-      },
-      {
-        "Name": "r_universe",
-        "URL": "https://cct-datascience.r-universe.dev"
-      },
-      {
-        "Name": "r_universe",
-        "URL": "https://cct-datascience.r-universe.dev"
-      },
-      {
         "Name": "CRAN",
         "URL": "https://packagemanager.posit.co/cran/latest"
       }
@@ -1948,9 +1928,15 @@
     },
     "zentracloud": {
       "Package": "zentracloud",
-      "Version": "0.4.6",
-      "Source": "Repository",
-      "Repository": "https://cct-datascience.r-universe.dev",
+      "Version": "0.4.9",
+      "Source": "GitLab",
+      "RemoteType": "gitlab",
+      "RemoteHost": "gitlab.com",
+      "RemoteUsername": "meter-group-inc",
+      "RemoteRepo": "pubpackages/zentracloud",
+      "RemoteSubdir": "",
+      "RemoteRef": "main",
+      "RemoteSha": "da3bb813674389445aa465d8e6a954ab8aeec871",
       "Requirements": [
         "R",
         "arrow",
@@ -1967,7 +1953,7 @@
         "tidyr",
         "uuid"
       ],
-      "Hash": "2a999464851f09ac6641d59c3450fd88"
+      "Hash": "160bece78cd4a47766a8a966d9163463"
     },
     "zip": {
       "Package": "zip",

--- a/renv.lock
+++ b/renv.lock
@@ -1,7 +1,11 @@
 {
   "R": {
-    "Version": "4.3.2",
+    "Version": "4.3.3",
     "Repositories": [
+      {
+        "Name": "r_universe",
+        "URL": "https://cct-datascience.r-universe.dev"
+      },
       {
         "Name": "r_universe",
         "URL": "https://cct-datascience.r-universe.dev"
@@ -925,7 +929,7 @@
     },
     "httr2": {
       "Package": "httr2",
-      "Version": "0.2.3",
+      "Version": "1.0.2",
       "Source": "Repository",
       "Repository": "RSPM",
       "Requirements": [
@@ -934,13 +938,15 @@
         "cli",
         "curl",
         "glue",
+        "lifecycle",
         "magrittr",
         "openssl",
         "rappdirs",
         "rlang",
+        "vctrs",
         "withr"
       ],
-      "Hash": "193bb297368afbbb42dc85784a46b36e"
+      "Hash": "320c8fe23fcb25a6690ef7bdb6a3a705"
     },
     "ids": {
       "Package": "ids",

--- a/rsconnect/documents/gsi_wrangling.Rmd/viz.datascience.arizona.edu/ericrscott/gsilivinglab_-_wrangling_workflow.dcf
+++ b/rsconnect/documents/gsi_wrangling.Rmd/viz.datascience.arizona.edu/ericrscott/gsilivinglab_-_wrangling_workflow.dcf
@@ -5,7 +5,7 @@ account: ericrscott
 server: viz.datascience.arizona.edu
 hostUrl: https://viz.datascience.arizona.edu/__api__
 appId: 921
-bundleId: 5511
+bundleId: 5518
 url: https://viz.datascience.arizona.edu:443/content/aec57581-1d82-438a-a383-64b227c7620f/
 version: 1
 asMultiple: FALSE

--- a/rsconnect/documents/gsi_wrangling.Rmd/viz.datascience.arizona.edu/ericrscott/gsilivinglab_-_wrangling_workflow.dcf
+++ b/rsconnect/documents/gsi_wrangling.Rmd/viz.datascience.arizona.edu/ericrscott/gsilivinglab_-_wrangling_workflow.dcf
@@ -1,11 +1,11 @@
 name: gsilivinglab_-_wrangling_workflow
-title: GSILivingLab - wrangling workflow
+title: gsi_wrangling
 username: ericrscott
 account: ericrscott
 server: viz.datascience.arizona.edu
 hostUrl: https://viz.datascience.arizona.edu/__api__
 appId: 921
-bundleId: 4712
+bundleId: 5511
 url: https://viz.datascience.arizona.edu:443/content/aec57581-1d82-438a-a383-64b227c7620f/
 version: 1
 asMultiple: FALSE


### PR DESCRIPTION
This PR solves two problems:

1. The fact that ETo values seem to get updated by ZentraCloud and we want to keep the new values (closes #33)
2. `zentracloud::getReadings()` errors if a particular request returns no data which makes the entire workflow stop.  This PR includes a workaround.  See also https://gitlab.com/meter-group-inc/pubpackages/zentracloud/-/issues/44