### PR TITLE
Convert missing ETo data to emtpy tibble

### DIFF
--- a/R/gsi_get_eto.R
+++ b/R/gsi_get_eto.R
@@ -4,7 +4,7 @@
 #' https://zentracloud.com/api/v3/documentation/?) and returns a tibble.  This
 #' function works for a single device only and returns data for the previous 30
 #' days.
-#' 
+#'
 #' @param device_sn Device ID
 #' @param port_num Port number for ATMOS sensor, currently 1 for all sites (this
 #'   is the default)
@@ -12,66 +12,91 @@
 #' @param elevation Elevation in meters
 #' @param latitude Latitude of device
 #'
-#' @return a tibble
+#' @returns a tibble, possibly empty (0x0) if no data is returned from the API
 #' @examples
 #' #for Old Main
 #' gsi_get_eto(device_sn = "z6-19484", wind_height = 2.1, elevation = 735, latitude = 32.231622)
-#' 
-gsi_get_eto <- function(device_sn, port_num = 1,  wind_height, elevation, latitude) {
+#'
+gsi_get_eto <- function(
+  device_sn,
+  port_num = 1,
+  wind_height,
+  elevation,
+  latitude
+) {
   #Create a request
-  req <- 
-    request("https://zentracloud.com/api/v4") |> 
-    req_url_path_append("get_env_model_data") |> 
+  req <-
+    request("https://zentracloud.com/api/v4") |>
+    req_url_path_append("get_env_model_data") |>
     req_url_query(
       device_sn = device_sn,
       model_type = "ETo", #only other option is ETr, so just hard-coded for now
-      port_num = port_num, 
+      port_num = port_num,
       # inputs = '{"elevation": 806, "latitude": 32.25, "wind_measurement_height": 2}'
-      inputs = toJSON(list(
-        elevation = elevation,
-        latitude = latitude,
-        wind_measurment_height = wind_height
-      ), auto_unbox  = TRUE) #removes [] from length 1 numeric vectors in JSON. Possibly not necessary
-    ) |> 
+      inputs = toJSON(
+        list(
+          elevation = elevation,
+          latitude = latitude,
+          wind_measurment_height = wind_height
+        ),
+        auto_unbox = TRUE
+      ) #removes [] from length 1 numeric vectors in JSON. Possibly not necessary
+    ) |>
     req_headers(
       Authorization = paste("Token", Sys.getenv("ZENTRACLOUD_TOKEN")),
       accept = "application/json"
-    ) |> 
-    req_throttle(rate = 1/62) |> #ridiculously slow API limit
+    ) |>
+    req_throttle(rate = 1 / 62) |> #ridiculously slow API limit
     req_retry() #retry in case throttle doesn't work
-  
+
   #View the request
   # req
-  
+
   #Perform the request
-  resp <- req |> 
+  resp <- req |>
     req_perform()
-  
+  browser()
   #Extract data from the request
-  
-  output <- resp |> 
+
+  output_string <- resp |>
     #extremely annoying that response is not JSON like it claims
-    resp_body_string() |> 
+    resp_body_string()
+
+  #If no data, response is the text "No records for this timerange" rather than an empty response
+  if (str_detect(output_string, "(N|n)o records")) {
+    return(tibble())
+  }
+
+  output <- output_string |>
     #extremely annoying that there are invalid values (unquoted NaN) in the JSON text
-    str_replace_all(pattern = 'NaN', replacement = '"NaN"') |> 
+    str_replace_all(pattern = 'NaN', replacement = '"NaN"') |>
     fromJSON()
-  
+
   eto_units <- str_trim(output$data$metadata$units)
-  
+
   #add metadata to data where appropriate
   out_df <- as_tibble(output$data$readings)
-  out_final <- out_df |> 
-    tibble::add_column(device_sn = device_sn, port = port_num, ETo.units = eto_units) |> 
+  out_final <- out_df |>
+    tibble::add_column(
+      device_sn = device_sn,
+      port = port_num,
+      ETo.units = eto_units
+    ) |>
     #rename to match other data columns
     rename(
       ETo.value = value,
       ETo.error_flag = error_flag,
       ETo.error_description = error_description
-    ) |> 
+    ) |>
     mutate(
-      datetime = parse_date_time(datetime, orders = "%Y-%m-%d %H:%M:%S%z", exact = TRUE) |> 
-        with_tz("America/Phoenix") |> as_date()
-    ) |> 
+      datetime = parse_date_time(
+        datetime,
+        orders = "%Y-%m-%d %H:%M:%S%z",
+        exact = TRUE
+      ) |>
+        with_tz("America/Phoenix") |>
+        as_date()
+    ) |>
     select(device_sn, port, datetime, starts_with("ETo"))
   out_final
 }


### PR DESCRIPTION
Fixes #40.  Detects "No records for this timerange" in API response and converts to an empty tibble.  *might* still be a problem if all three sites have no ETo data, but the workflow should run if at lest one has data.